### PR TITLE
feat: Remember active project across reloads

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   outputChannel.appendLine("Beads extension activating...");
 
   // Initialize the project manager
-  projectManager = new BeadsProjectManager(outputChannel);
+  projectManager = new BeadsProjectManager(context, outputChannel);
   await projectManager.initialize();
 
   // Create view providers


### PR DESCRIPTION
## Summary
- Persist selected project ID to VS Code workspace state
- Restore previous selection on extension activation
- Falls back to first project if saved project no longer exists

## Test plan
- [ ] Select a project other than the first one
- [ ] Reload VS Code window
- [ ] Verify the same project is still selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)