### PR TITLE
fix(ui): sort labels alphabetically (case-insensitive)

### DIFF
--- a/src/webview/types.ts
+++ b/src/webview/types.ts
@@ -172,6 +172,12 @@ export const TYPE_TEXT_COLORS: Record<BeadType, string> = {
   chore: "#ffffff",
 };
 
+/** Sort labels alphabetically (case-insensitive) */
+export function sortLabels(labels: string[] | undefined): string[] {
+  if (!labels) return [];
+  return [...labels].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+}
+
 // VS Code API interface for webview
 declare global {
   interface Window {

--- a/src/webview/views/DetailsView.tsx
+++ b/src/webview/views/DetailsView.tsx
@@ -21,6 +21,7 @@ import {
   STATUS_COLORS,
   TYPE_COLORS,
   TYPE_LABELS,
+  sortLabels,
 } from "../types";
 
 // Labels for dependency sections based on array (direction) and type
@@ -377,7 +378,7 @@ export function DetailsView({
         <div className="details-section">
           <h4>Labels</h4>
           <div className="labels-row">
-            {(displayBead.labels || []).map((label) => (
+            {sortLabels(displayBead.labels).map((label) => (
               <LabelBadge
                 key={label}
                 label={label}

--- a/src/webview/views/IssuesView.tsx
+++ b/src/webview/views/IssuesView.tsx
@@ -21,6 +21,7 @@ import {
   PRIORITY_COLORS,
   TYPE_LABELS,
   TYPE_COLORS,
+  sortLabels,
   vscode,
 } from "../types";
 import { StatusBadge } from "../common/StatusBadge";
@@ -679,7 +680,7 @@ export function IssuesView({
                       )}
                       {col.id === "labels" && (
                         <>
-                          {bead.labels?.map((label) => (
+                          {sortLabels(bead.labels).map((label) => (
                             <LabelBadge key={label} label={label} />
                           ))}
                         </>


### PR DESCRIPTION
## Summary
- Labels in Issues list and Details panel now display in alphabetical order
- Uses `localeCompare` with `sensitivity: 'base'` for case-insensitive sorting
- Extracted `sortLabels()` helper to `types.ts` for reuse

## Test plan
- [ ] Create/find bead with mixed-case labels (e.g., E, a, b, c, d)
- [ ] Verify labels display as a, b, c, d, E (alphabetical regardless of case)
- [ ] Check both Issues list column and Details panel

Resolves: vsbeads-qtl

🤖 Generated with [Claude Code](https://claude.com/claude-code)