### PR TITLE
feat(ui): render comments with markdown support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Assignee and Estimate columns (hidden by default) (`vsbeads-kz0`)
+- Comments render with markdown support (`vsbeads-rtk`)
 
 ### Fixed
 

--- a/src/webview/views/DetailsView.tsx
+++ b/src/webview/views/DetailsView.tsx
@@ -610,7 +610,9 @@ export function DetailsView({
                   {new Date(comment.createdAt).toLocaleDateString()}
                 </span>
               </div>
-              <div className="comment-text">{comment.text}</div>
+              <div className="comment-text">
+                <TextContent content={comment.text} renderMarkdown={renderMarkdown} />
+              </div>
             </div>
           ))}
           {(displayBead.comments || []).length === 0 && (


### PR DESCRIPTION
## Summary
- Comments in Details view now render markdown formatting
- Uses existing `TextContent`/`Markdown` component (one-line change)

## Test plan
- [ ] Add comment with markdown: `**bold** and `code``
- [ ] Verify formatting renders correctly

Resolves: vsbeads-rtk

🤖 Generated with [Claude Code](https://claude.com/claude-code)