### PR TITLE
fix: auto-recover from stale daemon socket after reboot

### DIFF
--- a/src/providers/BaseViewProvider.ts
+++ b/src/providers/BaseViewProvider.ts
@@ -187,6 +187,16 @@ export abstract class BaseViewProvider implements vscode.WebviewViewProvider {
   }
 
   /**
+   * Handles daemon connection errors - logs and notifies ProjectManager
+   * Views show error state in UI; centralized notification handled by ProjectManager
+   */
+  protected handleDaemonError(message: string, err: unknown): void {
+    this.log.error(`${message}: ${err}`);
+    // ProjectManager handles the notification - views just update their error state
+    this.projectManager.notifyDaemonError(err);
+  }
+
+  /**
    * Triggers a refresh of the view
    */
   public refresh(): void {

--- a/src/providers/BeadDetailsViewProvider.ts
+++ b/src/providers/BeadDetailsViewProvider.ts
@@ -112,7 +112,7 @@ export class BeadDetailsViewProvider extends BaseViewProvider {
     } catch (err) {
       this.setError(String(err));
       this.postMessage({ type: "setBead", bead: null });
-      this.log.errorNotify(`Failed to load bead details: ${err}`);
+      this.handleDaemonError("Failed to load bead details", err);
     } finally {
       this.setLoading(false);
     }

--- a/src/providers/BeadsPanelViewProvider.ts
+++ b/src/providers/BeadsPanelViewProvider.ts
@@ -52,7 +52,7 @@ export class BeadsPanelViewProvider extends BaseViewProvider {
     } catch (err) {
       this.setError(String(err));
       this.postMessage({ type: "setBeads", beads: [] });
-      this.log.errorNotify(`Failed to load beads: ${err}`);
+      this.handleDaemonError("Failed to load beads", err);
     } finally {
       this.setLoading(false);
     }

--- a/src/providers/DashboardViewProvider.ts
+++ b/src/providers/DashboardViewProvider.ts
@@ -99,7 +99,7 @@ export class DashboardViewProvider extends BaseViewProvider {
       this.postMessage({ type: "setBeads", beads: importantBeads });
     } catch (err) {
       this.setError(String(err));
-      this.log.errorNotify(`Failed to load dashboard: ${err}`);
+      this.handleDaemonError("Failed to load dashboard", err);
     } finally {
       this.setLoading(false);
     }


### PR DESCRIPTION
## Summary
- Auto-start daemon when stale socket detected (ECONNREFUSED on existing socket)
- Add "Restart Daemon" action to error notifications for easy recovery
- New `handleDaemonError()` helper in BaseViewProvider

## Problem
After system reboot, stale `.beads/bd.sock` files remain but daemon isn't running. Extension detected socket, tried to connect, got ECONNREFUSED, but didn't auto-start because auto-start only triggered when socket file was missing entirely.

## Test plan
- [ ] Reboot system or manually stop daemon while leaving socket file
- [ ] Open VS Code - extension should auto-recover
- [ ] Verify error notification has "Restart Daemon" button
- [ ] Click "Restart Daemon" - daemon should restart and data reload

Resolves: vsbeads-ugm

🤖 Generated with [Claude Code](https://claude.com/claude-code)