### PR TITLE
Add Windows TCP socket support for daemon connection

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/dist/**/*.js"
+      ],
+      "preLaunchTask": "${defaultBuildTask}"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,14 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "compile",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": []
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

On Windows, the Beads daemon creates a TCP socket and writes connection info to `bd.sock` as JSON:
{"network":"tcp","address":"127.0.0.1:45902"}

The extension was treating bd.sock as a Unix domain socket path, causing this error:
Error: Socket error: connect ENOTSOCK \.beads\bd.sock

## Solution
Added cross-platform socket detection in BeadsDaemonClient:

New getSocketConnection() method parses bd.sock to detect socket type
Connects via TCP when network: "tcp" is detected (Windows)
Falls back to Unix domain socket for standard sockets (Linux/macOS)
Updated class documentation to reflect cross-platform support

Modified:
src/backend/BeadsDaemonClient.ts - Added TCP socket support

Added:
.vscode/launch.json - Debug configuration for extension development
.vscode/tasks.json - Build task configuration

Testing
Tested on Windows 11 with Beads daemon running on TCP socket. Extension now successfully connects and communicates with the daemon.

Backward Compatibility
✅ Fully backward compatible - Unix socket behavior unchanged. If JSON parsing fails, falls back to original Unix socket connection.