### PR TITLE
fix: clicking bead ID now also selects row and updates details panel

### DIFF
--- a/src/webview/views/IssuesView.tsx
+++ b/src/webview/views/IssuesView.tsx
@@ -177,6 +177,7 @@ export function IssuesView({
               onClick={(e) => {
                 e.stopPropagation();
                 handleCopyId(info.row.original.id);
+                onSelectBead(info.row.original.id);
               }}
               title={copiedId === info.row.original.id ? "Copied!" : "Click to copy"}
             >


### PR DESCRIPTION
## Summary
- Clicking bead ID in Issues list now copies to clipboard AND selects the row
- Details panel updates immediately when clicking on the ID

## Problem
Previously `e.stopPropagation()` prevented the row click handler from firing, so clicking the bead ID only copied but didn't select.

## Test plan
- [ ] Click on a bead ID in the Issues list
- [ ] Verify ID is copied to clipboard (toast/visual feedback)
- [ ] Verify row becomes selected (highlighted)
- [ ] Verify Details panel updates to show that bead

Resolves: vsbeads-qgo

🤖 Generated with [Claude Code](https://claude.com/claude-code)