### PR TITLE
feat: move labels inline with type/status/priority badges

### DIFF
--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -1378,6 +1378,25 @@ textarea {
   align-items: center;
 }
 
+.badges-spacer {
+  flex: 1;
+}
+
+.add-label-inline input {
+  padding: 2px 6px;
+  font-size: 11px;
+  border: 1px dashed var(--vscode-panel-border);
+  border-radius: var(--border-radius);
+  background: transparent;
+  color: var(--vscode-foreground);
+  width: 70px;
+}
+
+.add-label-inline input:focus {
+  border-style: solid;
+  outline: none;
+}
+
 .badge-select,
 .badge-input {
   padding: 2px 6px;

--- a/src/webview/views/DetailsView.tsx
+++ b/src/webview/views/DetailsView.tsx
@@ -291,7 +291,7 @@ export function DetailsView({
         )}
       </div>
 
-      {/* Type/Status/Priority chiclets */}
+      {/* Type/Status/Priority chiclets + Labels */}
       <div className="details-badges">
         {editMode ? (
           <>
@@ -310,6 +310,24 @@ export function DetailsView({
               options={PRIORITY_OPTIONS}
               onChange={(v) => handleFieldChange("priority", v)}
             />
+            {/* Labels in edit mode - pushed to right, input first */}
+            <span className="badges-spacer" />
+            <div className="add-label-inline">
+              <input
+                type="text"
+                value={newLabel}
+                onChange={(e) => setNewLabel(e.target.value)}
+                placeholder="+ label"
+                onKeyDown={(e) => e.key === "Enter" && handleAddLabel()}
+              />
+            </div>
+            {sortLabels(displayBead.labels).map((label) => (
+              <LabelBadge
+                key={label}
+                label={label}
+                onRemove={() => handleRemoveLabel(label)}
+              />
+            ))}
           </>
         ) : (
           <>
@@ -337,6 +355,15 @@ export function DetailsView({
               renderOption={(opt) => <PriorityBadge priority={opt.value as BeadPriority} size="small" />}
               showChevron={false}
             />
+            {/* Labels inline in display mode - pushed to right */}
+            {displayBead.labels && displayBead.labels.length > 0 && (
+              <>
+                <span className="badges-spacer" />
+                {sortLabels(displayBead.labels).map((label) => (
+                  <LabelBadge key={label} label={label} />
+                ))}
+              </>
+            )}
           </>
         )}
       </div>
@@ -376,33 +403,6 @@ export function DetailsView({
           <p className="description-text muted">No description</p>
         )}
       </div>
-
-      {/* Labels - hide when empty in view mode */}
-      {(editMode || (displayBead.labels && displayBead.labels.length > 0)) && (
-        <div className="details-section">
-          <h4>Labels</h4>
-          <div className="labels-row">
-            {sortLabels(displayBead.labels).map((label) => (
-              <LabelBadge
-                key={label}
-                label={label}
-                onRemove={editMode ? () => handleRemoveLabel(label) : undefined}
-              />
-            ))}
-            {editMode && (
-              <div className="add-inline">
-                <input
-                  type="text"
-                  value={newLabel}
-                  onChange={(e) => setNewLabel(e.target.value)}
-                  placeholder="+ label"
-                  onKeyDown={(e) => e.key === "Enter" && handleAddLabel()}
-                />
-              </div>
-            )}
-          </div>
-        </div>
-      )}
 
       {/* External Reference & Estimate row */}
       {(displayBead.externalRef || displayBead.estimatedMinutes || editMode) && (


### PR DESCRIPTION
## Summary
- Labels now display on the same row as type/status/priority badges
- Labels are pushed to the right side with a flex spacer
- In edit mode, the "+ label" input appears before existing labels

## Before
Labels were in a separate section below description/design/notes.

## After
Labels appear inline, right-aligned on the badges row.

## Test plan
- [ ] View a bead with labels - labels should appear on the right side of the badges row
- [ ] View a bead without labels - no empty space or placeholder
- [ ] Edit mode - "+ label" input appears first, then existing labels
- [ ] Add a new label in edit mode - appears in the row
- [ ] Remove a label in edit mode - disappears from the row

Resolves: vsbeads-677

🤖 Generated with [Claude Code](https://claude.com/claude-code)