### PR TITLE
fix: add retry for transient daemon errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ tmp/
 # Local dev artifacts (code-server, openvscode-server)
 .cache/
 .openvscode-server/
+
+# Local environment notes (not committed)
+CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,12 @@ bun run package          # Create VSIX package
 
 ## Development Workflow
 
+**Always branch before making changes.** Never commit directly to main. Create a feature branch before any code changes:
+```bash
+git checkout -b fix/descriptive-name   # or feat/, chore/, etc.
+```
+Exception: If already on a feature branch and told to continue on it (e.g., multiple beads under one PR).
+
 **Testing workflow with Chrome DevTools MCP**: After building, ask the user to reload code-server and test. Don't automate the reload/test cycle via browser tools - it wastes context.
 
 **code-server for testing**: See `docs/code-server-testing.md` - living document for agent reference. Keep it updated with working config and lessons learned.


### PR DESCRIPTION
## Summary

- Add client-side retry logic to `BeadsDaemonClient` for transient daemon errors
- Retry up to 2 times with increasing delay (100ms, 200ms) for errors like "database is closed"
- Workaround for upstream race condition in FreshnessChecker

## Context

After upgrading to bd v0.30.2, we see intermittent "sql: database is closed" errors. Investigation found a potential race condition in the daemon's FreshnessChecker reconnection logic.

**Upstream issue:** https://github.com/steveyegge/beads/issues/607

This is a client-side mitigation until the upstream fix lands. Code is marked with a comment linking to the issue for cleanup.

## Also included

- Add "always branch before changes" guidance to CLAUDE.md
- Add `CLAUDE.local.md` to .gitignore for local environment notes

## Test plan

- [ ] Build succeeds
- [ ] Extension loads without errors
- [ ] Transient errors should be retried transparently

Related: vsbeads-m98

🤖 Generated with [Claude Code](https://claude.com/claude-code)