### PR TITLE
fix: normalize control heights to 20px across panels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,9 @@ Use beads MCP tools for ALL issue tracking. Do NOT use TodoWrite or markdown TOD
 
 **When creating beads**: Add a category label (e.g., `ui`, `backend`, `daemon`, `docs`, `dx`).
 
-**Do NOT close issues prematurely.** Wait for explicit user verification that the work is complete before closing. Build succeeding is not enough - the user must confirm the feature works as expected.
+**Working on a bead**: When user says "work on", "activate", "look at", or similar for an issue, set it to `in_progress` and assign to `jdillon`. Keep beads `in_progress` until user explicitly closes or requests close.
+
+**NEVER close issues without explicit permission.** Even after user verification, DO NOT close beads until the full workflow is complete: branch created, code committed, pushed, and user explicitly says "close" or "done". User verification that something works is NOT permission to close - that's just testing. Ask "ready to close?" if unsure.
 
 **Updating notes**: Append new information, don't replace existing content. Use `---` separator for dated updates. Only replace if explicitly asked.
 

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -19,7 +19,7 @@
   --transition-normal: 0.25s ease;
 
   /* Badge sizes - consistent heights across all badge types */
-  --badge-height-sm: 18px;
+  --badge-height-sm: 20px;
   --badge-height-md: 20px;
   --badge-height-lg: 24px;
   --badge-font-sm: 10px;
@@ -812,7 +812,8 @@ textarea {
   gap: 4px;
   padding: 2px 6px;
   font-size: 12px;
-  height: auto;
+  height: var(--badge-height-sm);
+  line-height: 1;
 }
 
 .preset-dropdown-menu {
@@ -826,6 +827,8 @@ textarea {
   gap: 4px;
   padding: 2px 8px 2px 10px;
   font-size: 12px;
+  height: var(--badge-height-sm);
+  line-height: 1;
   background: transparent;
   color: var(--vscode-foreground);
   border: 1px solid var(--vscode-panel-border);
@@ -1555,6 +1558,8 @@ textarea {
   align-items: center;
   gap: 4px;
   padding: 2px 6px;
+  height: var(--badge-height-sm);
+  line-height: 1;
   background: transparent;
   border: 1px solid var(--vscode-panel-border);
   border-left: 3px solid var(--chip-accent-color, var(--vscode-panel-border));


### PR DESCRIPTION
## Summary
- Normalize `--badge-height-sm` from 18px to 20px for consistent control heights
- Fix filter chips, colored select triggers, and preset dropdowns to use explicit height
- Update CLAUDE.md with clearer beads workflow instructions (when to set in_progress, never close without permission)

## Test plan
- [x] Verify filter bar controls (Not Closed dropdown, filter chips) are 20px
- [x] Verify Details panel controls (type, status, priority badges) match filter bar height
- [x] Visual inspection confirms consistent heights across panels

Resolves: vsbeads-cf6

🤖 Generated with [Claude Code](https://claude.com/claude-code)