### PR TITLE
fix: add edit mode support for external_ref and estimate fields

### DIFF
--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -1503,6 +1503,16 @@ textarea {
   padding: 4px 8px;
 }
 
+.text-input {
+  width: 100%;
+  font-size: 12px;
+  padding: 4px 8px;
+}
+
+.estimate-input {
+  width: 120px;
+}
+
 .details-badges {
   display: flex;
   flex-wrap: wrap;

--- a/src/webview/views/DetailsView.tsx
+++ b/src/webview/views/DetailsView.tsx
@@ -499,21 +499,42 @@ export function DetailsView({
         )}
       </div>
 
-      {/* External Reference - only show if has data */}
-      {displayBead.externalRef && (
+      {/* External Reference */}
+      {(displayBead.externalRef || editMode) && (
         <div className="details-section compact">
           <h4>External Reference</h4>
-          <ExternalRefValue value={displayBead.externalRef} />
+          {editMode ? (
+            <input
+              type="text"
+              value={displayBead.externalRef || ""}
+              onChange={(e) => handleFieldChange("externalRef", e.target.value || null)}
+              className="text-input"
+              placeholder="URL or reference ID"
+            />
+          ) : (
+            <ExternalRefValue value={displayBead.externalRef} />
+          )}
         </div>
       )}
 
-      {/* Estimate - only show if has data */}
-      {displayBead.estimatedMinutes && (
+      {/* Estimate */}
+      {(displayBead.estimatedMinutes || editMode) && (
         <div className="details-section compact">
-          <h4>Estimate</h4>
-          <span className="estimate-value">
-            {Math.floor(displayBead.estimatedMinutes / 60)}h {displayBead.estimatedMinutes % 60}m
-          </span>
+          <h4>Estimate (minutes)</h4>
+          {editMode ? (
+            <input
+              type="number"
+              value={displayBead.estimatedMinutes || ""}
+              onChange={(e) => handleFieldChange("estimatedMinutes", e.target.value ? parseInt(e.target.value, 10) : null)}
+              className="text-input estimate-input"
+              placeholder="Minutes"
+              min="0"
+            />
+          ) : (
+            <span className="estimate-value">
+              {Math.floor(displayBead.estimatedMinutes! / 60)}h {displayBead.estimatedMinutes! % 60}m
+            </span>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Add text input for External Reference field in edit mode
- Add number input for Estimate (minutes) field in edit mode
- Add supporting CSS styles for new inputs

## Test plan
- [x] Build succeeds
- [x] Edit mode shows External Reference input
- [x] Edit mode shows Estimate input
- [ ] Verify saving external_ref value works
- [ ] Verify saving estimate value works

Resolves: vsbeads-96o, vsbeads-7r2

🤖 Generated with [Claude Code](https://claude.com/claude-code)