### PR TITLE
fix: eliminate excessive spacing in markdown lists

### DIFF
--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -1789,16 +1789,16 @@ textarea {
   margin: 0 !important;
   padding: 0 0 0 1.2em !important;
   list-style-position: outside;
+  /* Eliminate whitespace between list items */
+  font-size: 0;
 }
 
 .markdown-content li {
   margin: 0 !important;
   padding: 0 !important;
   line-height: 1.3;
-}
-
-.markdown-content li + li {
-  margin-top: 0 !important;
+  /* Restore font size after zeroing on UL */
+  font-size: 12px;
 }
 
 .markdown-content p + ul,


### PR DESCRIPTION
## Summary
- Use `font-size: 0` on UL/OL elements to eliminate whitespace between HTML elements that was creating anonymous line boxes
- Restore `font-size: 12px` on LI elements
- Removes ~15px gaps between list items that persisted despite margin/padding being 0

## Test plan
- [x] View any bead with markdown lists (e.g., vsbeads-m98)
- [x] Verify list items are tightly spaced without excessive gaps
- [x] Build succeeds

Resolves: vsbeads-l27

🤖 Generated with [Claude Code](https://claude.com/claude-code)