### PR TITLE
feat: add type sort order for consistent epic-first display

### DIFF
--- a/src/webview/types.ts
+++ b/src/webview/types.ts
@@ -174,6 +174,27 @@ export const TYPE_TEXT_COLORS: Record<BeadType, string> = {
   chore: "#ffffff",
 };
 
+// Sort order for type display (lower = first)
+// Epic first, then feature (story), bug, task, chore, then newer workflow types
+export const TYPE_SORT_ORDER: Record<string, number> = {
+  epic: 0,
+  feature: 1,
+  bug: 2,
+  task: 3,
+  chore: 4,
+  "merge-request": 5,
+  molecule: 6,
+};
+
+// Default sort order for unknown types (sorts after known types)
+export const UNKNOWN_TYPE_SORT_ORDER = 99;
+
+/** Get sort order for a type (handles unknown types) */
+export function getTypeSortOrder(type: string | undefined): number {
+  if (!type) return UNKNOWN_TYPE_SORT_ORDER;
+  return TYPE_SORT_ORDER[type] ?? UNKNOWN_TYPE_SORT_ORDER;
+}
+
 /** Sort labels alphabetically (case-insensitive) */
 export function sortLabels(labels: string[] | undefined): string[] {
   if (!labels) return [];

--- a/src/webview/views/DetailsView.tsx
+++ b/src/webview/views/DetailsView.tsx
@@ -21,6 +21,8 @@ import {
   STATUS_COLORS,
   TYPE_COLORS,
   TYPE_LABELS,
+  TYPE_SORT_ORDER,
+  getTypeSortOrder,
   sortLabels,
 } from "../types";
 import { Timestamp } from "../common/Timestamp";
@@ -123,12 +125,14 @@ import { useToast } from "../common/Toast";
 import { ColoredSelect, ColoredSelectOption } from "../common/ColoredSelect";
 import { Dropdown, DropdownItem } from "../common/Dropdown";
 
-// Build options for ColoredSelect dropdowns
-const TYPE_OPTIONS: ColoredSelectOption<BeadType>[] = (Object.keys(TYPE_LABELS) as BeadType[]).map((t) => ({
-  value: t,
-  label: TYPE_LABELS[t],
-  color: TYPE_COLORS[t],
-}));
+// Build options for ColoredSelect dropdowns (sorted by TYPE_SORT_ORDER)
+const TYPE_OPTIONS: ColoredSelectOption<BeadType>[] = (Object.keys(TYPE_LABELS) as BeadType[])
+  .sort((a, b) => getTypeSortOrder(a) - getTypeSortOrder(b))
+  .map((t) => ({
+    value: t,
+    label: TYPE_LABELS[t],
+    color: TYPE_COLORS[t],
+  }));
 
 const STATUS_OPTIONS: ColoredSelectOption<BeadStatus>[] = (Object.keys(STATUS_LABELS) as BeadStatus[]).map((s) => ({
   value: s,

--- a/src/webview/views/IssuesView.tsx
+++ b/src/webview/views/IssuesView.tsx
@@ -35,6 +35,8 @@ import {
   PRIORITY_COLORS,
   TYPE_LABELS,
   TYPE_COLORS,
+  TYPE_SORT_ORDER,
+  getTypeSortOrder,
   sortLabels,
   vscode,
 } from "../types";
@@ -67,7 +69,17 @@ interface IssuesViewProps {
   onRetry: () => void;
 }
 
-const ISSUE_TYPES = ["bug", "feature", "task", "epic", "chore"];
+// Issue types sorted by TYPE_SORT_ORDER (epic first)
+const ISSUE_TYPES = Object.keys(TYPE_SORT_ORDER).sort(
+  (a, b) => getTypeSortOrder(a) - getTypeSortOrder(b)
+);
+
+// Custom sorting function for type columns (epic first)
+const typeSortingFn = (rowA: { getValue: (id: string) => unknown }, rowB: { getValue: (id: string) => unknown }) => {
+  const a = getTypeSortOrder(rowA.getValue("type") as string | undefined);
+  const b = getTypeSortOrder(rowB.getValue("type") as string | undefined);
+  return a - b;
+};
 
 // Filter presets
 interface FilterPreset {
@@ -157,6 +169,7 @@ export function IssuesView({
           info.getValue() ? (
             <TypeIcon type={info.getValue() as BeadType} size={16} />
           ) : null,
+        sortingFn: typeSortingFn,
       }),
       columnHelper.accessor("type", {
         header: "Type",
@@ -166,6 +179,7 @@ export function IssuesView({
           info.getValue() ? (
             <TypeBadge type={info.getValue() as BeadType} size="small" />
           ) : null,
+        sortingFn: typeSortingFn,
         filterFn: (row, columnId, filterValue: string[]) => {
           if (!filterValue || filterValue.length === 0) return true;
           const val = row.getValue(columnId) as string | undefined;


### PR DESCRIPTION
## Summary
- Add `TYPE_SORT_ORDER` constant defining display order: epic → feature → bug → task → chore → merge-request → molecule
- Add `getTypeSortOrder()` helper function for custom table column sorting
- Sort type filter menu and type dropdown by defined order
- Add `typeSortingFn` for icon and type columns in issues table

## Test plan
- [ ] Verify type filter menu shows types in epic-first order
- [ ] Verify type dropdown in details view shows types in epic-first order
- [ ] Verify clicking icon column header sorts by type order (ascending = epic first)
- [ ] Verify clicking type column header sorts by type order (ascending = epic first)

Resolves: vsbeads-6d1

🤖 Generated with [Claude Code](https://claude.com/claude-code)