### PR TITLE
feat: add StatusPriorityPill component for consistent badge rendering

### DIFF
--- a/src/webview/common/StatusPriorityPill.tsx
+++ b/src/webview/common/StatusPriorityPill.tsx
@@ -1,0 +1,65 @@
+/**
+ * StatusPriorityPill Component
+ *
+ * Displays status and priority as a joined pill badge.
+ * Used in dependency lists for consistent rendering.
+ */
+
+import React from "react";
+import {
+  BeadStatus,
+  BeadPriority,
+  STATUS_LABELS,
+  STATUS_COLORS,
+  PRIORITY_COLORS,
+  PRIORITY_TEXT_COLORS,
+  UNKNOWN_PRIORITY_COLOR,
+  UNKNOWN_PRIORITY_TEXT_COLOR,
+} from "../types";
+
+interface StatusPriorityPillProps {
+  status?: BeadStatus;
+  priority?: BeadPriority;
+}
+
+export function StatusPriorityPill({
+  status,
+  priority,
+}: StatusPriorityPillProps): React.ReactElement | null {
+  // Need at least one value to render
+  if (!status && priority === undefined) return null;
+
+  const statusLabel = status ? STATUS_LABELS[status] : null;
+  const statusColor = status ? STATUS_COLORS[status] : null;
+
+  const priorityLabel = priority !== undefined ? `P${priority}` : "P?";
+  const priorityBgColor = priority !== undefined
+    ? PRIORITY_COLORS[priority]
+    : UNKNOWN_PRIORITY_COLOR;
+  const priorityTextColor = priority !== undefined
+    ? PRIORITY_TEXT_COLORS[priority]
+    : UNKNOWN_PRIORITY_TEXT_COLOR;
+
+  return (
+    <span className="status-priority-pill">
+      {status && (
+        <span
+          className="pill-status"
+          style={{ backgroundColor: statusColor || undefined }}
+        >
+          {statusLabel}
+        </span>
+      )}
+      <span
+        className="pill-priority"
+        style={{
+          backgroundColor: priorityBgColor,
+          color: priorityTextColor,
+          borderRadius: status ? undefined : "var(--border-radius)",
+        }}
+      >
+        {priorityLabel}
+      </span>
+    </span>
+  );
+}

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -356,7 +356,7 @@ textarea {
 /* ==================== Status & Priority Badges ==================== */
 /*
  * Keep font-variant in sync with:
- * - .dep-status, .dep-priority (dependency list inline badges)
+ * - .status-priority-pill (dependency list joined pill)
  * - .filter-chip, .colored-select-label (filter UI)
  * - .type-badge, .label-badge (other badge types)
  */
@@ -389,6 +389,47 @@ textarea {
   height: var(--badge-height-md);
   line-height: 1;
   font-variant: small-caps;
+}
+
+/* Joined status+priority pill - used in dependency lists */
+.status-priority-pill {
+  display: inline-flex;
+  align-items: stretch;
+  gap: 1px;
+  height: 20px;
+  line-height: 1;
+}
+
+.status-priority-pill .pill-status,
+.status-priority-pill .pill-priority {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 6px;
+  font-size: 10px;
+  font-weight: 500;
+  white-space: nowrap;
+  font-variant: small-caps;
+}
+
+.status-priority-pill .pill-status {
+  color: #fff;
+  border-radius: var(--border-radius) 0 0 var(--border-radius);
+}
+
+.status-priority-pill .pill-priority {
+  font-weight: 600;
+  border-radius: 0 var(--border-radius) var(--border-radius) 0;
+}
+
+/* When only priority is shown (no status), use full border-radius */
+.status-priority-pill .pill-priority:only-child {
+  border-radius: var(--border-radius);
+}
+
+/* Position pill at end of dependency item */
+.dep-item .status-priority-pill {
+  margin-left: auto;
 }
 
 /* Small badges - used in list view and detail panel */
@@ -1936,35 +1977,6 @@ textarea {
   white-space: nowrap;
   flex: 1;
   min-width: 0;
-}
-
-.dep-indicators {
-  display: flex;
-  align-items: center;
-  gap: 2px;
-  margin-left: auto;
-}
-
-/*
- * Dependency item badges - inline "joined pill" variant
- * Keep font-variant in sync with: .status-badge, .priority-badge (styles.css)
- * See also: StatusBadge.tsx, PriorityBadge.tsx
- */
-.dep-status {
-  font-size: 10px;
-  font-weight: 500;
-  padding: 2px 6px;
-  color: #fff;
-  border-radius: var(--border-radius) 0 0 var(--border-radius);
-  font-variant: small-caps;
-}
-
-.dep-priority {
-  font-size: 10px;
-  font-weight: 600;
-  padding: 2px 6px;
-  border-radius: 0 var(--border-radius) var(--border-radius) 0;
-  font-variant: small-caps;
 }
 
 /* Type-based coloring for dependency items (matches filter chips) */

--- a/src/webview/views/DetailsView.tsx
+++ b/src/webview/views/DetailsView.tsx
@@ -17,9 +17,6 @@ import {
   BeadType,
   STATUS_LABELS,
   PRIORITY_COLORS,
-  PRIORITY_TEXT_COLORS,
-  UNKNOWN_PRIORITY_COLOR,
-  UNKNOWN_PRIORITY_TEXT_COLOR,
   STATUS_COLORS,
   TYPE_COLORS,
   TYPE_LABELS,
@@ -28,6 +25,7 @@ import {
   sortLabels,
 } from "../types";
 import { Timestamp } from "../common/Timestamp";
+import { StatusPriorityPill } from "../common/StatusPriorityPill";
 import { Icon } from "../icons";
 
 /**
@@ -617,25 +615,7 @@ export function DetailsView({
           >
             <span className="dep-id">{dep.id}</span>
             {dep.title && <span className="dep-title">{dep.title}</span>}
-            <span className="dep-indicators">
-              {dep.status && (
-                <span
-                  className="dep-status"
-                  style={{ backgroundColor: STATUS_COLORS[dep.status] }}
-                >
-                  {STATUS_LABELS[dep.status]}
-                </span>
-              )}
-              <span
-                className="dep-priority"
-                style={{
-                  backgroundColor: dep.priority !== undefined ? PRIORITY_COLORS[dep.priority] : UNKNOWN_PRIORITY_COLOR,
-                  color: dep.priority !== undefined ? PRIORITY_TEXT_COLORS[dep.priority] : UNKNOWN_PRIORITY_TEXT_COLOR
-                }}
-              >
-                {dep.priority !== undefined ? `P${dep.priority}` : "P?"}
-              </span>
-            </span>
+            <StatusPriorityPill status={dep.status} priority={dep.priority} />
             {allowRemove && editMode && (
               <button
                 className="dep-remove"


### PR DESCRIPTION
## Summary
- Create shared `StatusPriorityPill` component for joined status+priority badges
- Fixes inconsistent spacing in dependency list badges
- Uses 1px gap with 0 inner radius for clean joined pill look

## Changes
- New: `src/webview/common/StatusPriorityPill.tsx`
- Updated: `src/webview/styles.css` - added pill CSS, removed old dep-status/dep-priority
- Updated: `src/webview/views/DetailsView.tsx` - uses new component

## Test plan
- [x] Verify dependency list shows consistent spacing between status and priority
- [x] Verify P? shown for undefined priority
- [x] Verify pill positioned at end of dependency item

Resolves: vsbeads-f7ng

🤖 Generated with [Claude Code](https://claude.com/claude-code)