### PR TITLE
feat: add fallback handling for unknown bead types

### DIFF
--- a/src/webview/common/TypeBadge.tsx
+++ b/src/webview/common/TypeBadge.tsx
@@ -1,14 +1,21 @@
 /**
  * TypeBadge Component
  *
- * Displays bead type as a colored badge
+ * Displays bead type as a colored badge.
+ * Shows raw type name with gray background for unknown types.
  */
 
 import React from "react";
-import { BeadType, TYPE_LABELS, TYPE_COLORS, TYPE_TEXT_COLORS } from "../types";
+import {
+  TYPE_LABELS,
+  TYPE_COLORS,
+  TYPE_TEXT_COLORS,
+  UNKNOWN_TYPE_COLOR,
+  UNKNOWN_TYPE_TEXT_COLOR,
+} from "../types";
 
 interface TypeBadgeProps {
-  type: BeadType;
+  type: string;
   size?: "small" | "medium" | "large";
 }
 
@@ -16,9 +23,9 @@ export function TypeBadge({
   type,
   size = "medium",
 }: TypeBadgeProps): React.ReactElement {
-  const label = TYPE_LABELS[type] || type;
-  const bgColor = TYPE_COLORS[type] || "#888888";
-  const textColor = TYPE_TEXT_COLORS[type] || "#ffffff";
+  const label = TYPE_LABELS[type as keyof typeof TYPE_LABELS] || type;
+  const bgColor = TYPE_COLORS[type as keyof typeof TYPE_COLORS] || UNKNOWN_TYPE_COLOR;
+  const textColor = TYPE_TEXT_COLORS[type as keyof typeof TYPE_TEXT_COLORS] || UNKNOWN_TYPE_TEXT_COLOR;
 
   return (
     <span

--- a/src/webview/common/TypeIcon.tsx
+++ b/src/webview/common/TypeIcon.tsx
@@ -1,15 +1,16 @@
 /**
  * TypeIcon Component
  *
- * Displays an SVG icon for bead issue types using FontAwesome Free icons
+ * Displays an SVG icon for bead issue types using FontAwesome Free icons.
+ * Shows a notdef (missing glyph) icon for unknown types.
  */
 
 import React from "react";
-import { BeadType, TYPE_COLORS } from "../types";
+import { TYPE_COLORS, UNKNOWN_TYPE_COLOR } from "../types";
 import { icons } from "../icons";
 
 interface TypeIconProps {
-  type: BeadType;
+  type: string;
   size?: number;
   colored?: boolean;
 }
@@ -18,11 +19,14 @@ export function TypeIcon({
   type,
   size = 16,
   colored = true,
-}: TypeIconProps): React.ReactElement | null {
-  const svgContent = icons[type];
-  if (!svgContent) return null;
+}: TypeIconProps): React.ReactElement {
+  // Use known icon or fallback to notdef (missing glyph)
+  const svgContent = icons[type as keyof typeof icons] || icons.notdef;
 
-  const color = colored ? TYPE_COLORS[type] : "currentColor";
+  // Use known color or fallback to gray
+  const color = colored
+    ? (TYPE_COLORS[type as keyof typeof TYPE_COLORS] || UNKNOWN_TYPE_COLOR)
+    : "currentColor";
 
   // Inject fill color into SVG
   const coloredSvg = svgContent

--- a/src/webview/icons/index.ts
+++ b/src/webview/icons/index.ts
@@ -16,6 +16,7 @@ import wrenchSvg from "./wrench.svg";
 import userSvg from "./user.svg";
 import tagSvg from "./tag.svg";
 import externalLinkSvg from "./external-link.svg";
+import notdefSvg from "./notdef.svg";
 
 export const icons = {
   // Issue types
@@ -28,6 +29,7 @@ export const icons = {
   user: userSvg,
   tag: tagSvg,
   "external-link": externalLinkSvg,
+  notdef: notdefSvg,
 } as const;
 
 export type IconName = keyof typeof icons;

--- a/src/webview/icons/notdef.svg
+++ b/src/webview/icons/notdef.svg
@@ -1,0 +1,2 @@
+<!--! Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2024 Fonticons, Inc. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path d="M64 390.3L153.5 256 64 121.7l0 268.6zM102.5 448l179.1 0L192 313.7 102.5 448zm128-192L320 390.3l0-268.6L230.5 256zM281.5 64L102.5 64 192 198.3 281.5 64zM0 48C0 21.5 21.5 0 48 0L336 0c26.5 0 48 21.5 48 48l0 416c0 26.5-21.5 48-48 48L48 512c-26.5 0-48-21.5-48-48L0 48z"/></svg>

--- a/src/webview/types.ts
+++ b/src/webview/types.ts
@@ -178,6 +178,10 @@ export const TYPE_TEXT_COLORS: Record<BeadType, string> = {
   chore: "#ffffff",
 };
 
+// Colors for unknown/undefined type (shown with question mark icon)
+export const UNKNOWN_TYPE_COLOR = "#888888"; // gray
+export const UNKNOWN_TYPE_TEXT_COLOR = "#ffffff"; // white
+
 // Sort order for type display (lower = first)
 // Epic first, then feature (story), bug, task, chore, then newer workflow types
 export const TYPE_SORT_ORDER: Record<string, number> = {


### PR DESCRIPTION
## Summary
- Add question mark icon for unknown/unrecognized bead types
- Add fallback colors (gray background, white text) for unknown types
- Update TypeIcon and TypeBadge components to handle unknown types gracefully
- Change type props from strict `BeadType` to `string` for extensibility

## Test plan
- [ ] Verify existing bead types (bug, feature, task, epic, chore) render correctly
- [ ] Verify unknown types show question mark icon with gray styling
- [ ] Verify TypeBadge shows unknown types with fallback colors

Resolves: vsbeads-madg

🤖 Generated with [Claude Code](https://claude.com/claude-code)