### PR TITLE
fix: load embedded dolt projects without starting server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `beads.userId` and `beads.pathToBd` now expand `${env:VAR}` placeholders (#60)
+- Embedded Dolt projects now load Dashboard and Issues through the CLI backend without calling `bd dolt start`, including closed issues for the `All` filter.
 
 ## [0.13.0] - 2026-03-20
 

--- a/src/backend/BeadsBackendFactory.ts
+++ b/src/backend/BeadsBackendFactory.ts
@@ -1,0 +1,80 @@
+import { execFile } from "child_process";
+import * as util from "util";
+import type { Logger } from "../utils/logger";
+import { BeadsBackend } from "./BeadsBackend";
+import { BeadsCommandRunner } from "./BeadsCommandRunner";
+import { BeadsDoltBackend } from "./BeadsDoltBackend";
+
+const execFileAsync = util.promisify(execFile);
+
+export type BeadsBackendKind = "cli" | "dolt-sql";
+
+type BackendFactoryParams = {
+  bdPath: string;
+  cwd: string;
+  beadsDir: string;
+  log: Logger;
+  minSupportedVersion?: string;
+};
+
+type DoltShowInfo = {
+  embedded?: unknown;
+  mode?: unknown;
+  backend?: unknown;
+};
+
+export async function createBeadsBackend(params: BackendFactoryParams): Promise<BeadsBackend> {
+  const kind = await selectBackendKind(
+    () => readDoltShowInfo(params),
+    (error) => {
+      params.log.trace(`Unable to detect Dolt backend mode: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  );
+
+  if (kind === "cli") {
+    params.log.info("Using bd CLI backend for embedded Dolt project");
+    return new BeadsCommandRunner(params);
+  }
+
+  params.log.info("Using Dolt SQL backend");
+  return new BeadsDoltBackend(params);
+}
+
+export async function selectBackendKind(
+  readDoltShowInfo: () => Promise<DoltShowInfo>,
+  onDetectionError?: (error: unknown) => void
+): Promise<BeadsBackendKind> {
+  try {
+    const info = await readDoltShowInfo();
+    return isEmbeddedDoltInfo(info) ? "cli" : "dolt-sql";
+  } catch (error) {
+    onDetectionError?.(error);
+    return "dolt-sql";
+  }
+}
+
+function isEmbeddedDoltInfo(info: DoltShowInfo): boolean {
+  if (info.embedded === true) return true;
+
+  const mode = typeof info.mode === "string" ? info.mode.toLowerCase() : "";
+  const backend = typeof info.backend === "string" ? info.backend.toLowerCase() : "";
+  return mode.includes("embedded") || backend === "embedded";
+}
+
+async function readDoltShowInfo(params: BackendFactoryParams): Promise<DoltShowInfo> {
+  const { stdout } = await execFileAsync(params.bdPath, ["dolt", "show", "--json"], {
+    cwd: params.cwd,
+    env: {
+      ...process.env,
+      BEADS_DIR: params.beadsDir,
+    },
+    maxBuffer: 1024 * 1024,
+  });
+
+  const trimmed = stdout.trim();
+  if (!trimmed) {
+    throw new Error("No JSON output from bd dolt show --json");
+  }
+
+  return JSON.parse(trimmed) as DoltShowInfo;
+}

--- a/src/backend/BeadsCommandRunner.ts
+++ b/src/backend/BeadsCommandRunner.ts
@@ -38,6 +38,10 @@ function toStringArray(values?: string[]): string[] {
   return values.flatMap((v) => ["--label", v]);
 }
 
+export function createListCommandArgs(): string[] {
+  return ["list", "--all", "--limit", "0", "--json"];
+}
+
 export class BeadsCommandRunner implements BeadsBackend {
   private readonly bdPath: string;
   private readonly cwd: string;
@@ -77,7 +81,7 @@ export class BeadsCommandRunner implements BeadsBackend {
   }
 
   async list(): Promise<BeadsIssue[]> {
-    const result = await this.runReadJson(["list", "--json"], { cacheTtlMs: 750 });
+    const result = await this.runReadJson(createListCommandArgs(), { cacheTtlMs: 750 });
     return Array.isArray(result) ? (result as BeadsIssue[]) : [];
   }
 

--- a/src/backend/BeadsProjectManager.ts
+++ b/src/backend/BeadsProjectManager.ts
@@ -7,7 +7,7 @@ import * as vscode from "vscode";
 import { Logger } from "../utils/logger";
 import { resolveEnvVariables } from "../utils/resolve-env-variables";
 import { BeadsBackend } from "./BeadsBackend";
-import { BeadsDoltBackend } from "./BeadsDoltBackend";
+import { createBeadsBackend } from "./BeadsBackendFactory";
 import { BeadsProject } from "./types";
 
 const ACTIVE_PROJECT_KEY = "beads.activeProjectId";
@@ -389,7 +389,7 @@ export class BeadsProjectManager implements vscode.Disposable {
 
     const bdPath = this.getBdPath();
 
-    this.backend = new BeadsDoltBackend({
+    this.backend = await createBeadsBackend({
       bdPath,
       cwd: project.rootPath,
       beadsDir: project.beadsDir,

--- a/src/backend/__tests__/BeadsBackendFactory.test.ts
+++ b/src/backend/__tests__/BeadsBackendFactory.test.ts
@@ -1,0 +1,36 @@
+import { selectBackendKind } from "../BeadsBackendFactory";
+
+describe("selectBackendKind", () => {
+  it("uses the CLI backend for embedded Dolt projects", async () => {
+    const kind = await selectBackendKind(async () => ({
+      backend: "dolt",
+      data_dir: "/workspace/.beads/embeddeddolt",
+      database: "example",
+      embedded: true,
+      schema_version: 1,
+    }));
+
+    expect(kind).toBe("cli");
+  });
+
+  it("keeps the Dolt SQL backend for server-mode projects", async () => {
+    const kind = await selectBackendKind(async () => ({
+      host: "127.0.0.1",
+      port: 3306,
+      user: "root",
+      database: "example",
+      connection_ok: true,
+      shared_server: false,
+    }));
+
+    expect(kind).toBe("dolt-sql");
+  });
+
+  it("falls back to the Dolt SQL backend when mode detection fails", async () => {
+    const kind = await selectBackendKind(async () => {
+      throw new Error("bd dolt show failed");
+    });
+
+    expect(kind).toBe("dolt-sql");
+  });
+});

--- a/src/backend/__tests__/BeadsCommandRunner.test.ts
+++ b/src/backend/__tests__/BeadsCommandRunner.test.ts
@@ -1,0 +1,7 @@
+import { createListCommandArgs } from "../BeadsCommandRunner";
+
+describe("createListCommandArgs", () => {
+  it("requests all issues without the CLI default limit", () => {
+    expect(createListCommandArgs()).toEqual(["list", "--all", "--limit", "0", "--json"]);
+  });
+});


### PR DESCRIPTION
# Fix embedded Dolt projects in Dashboard and Issues

## Summary

Fixes Dashboard and Issues loading for Beads projects that use embedded Dolt mode.

Recent `bd` versions can run with an embedded in-process Dolt engine. In that mode there is no Dolt SQL server, so `bd dolt start` fails with:

```text
'bd dolt start' is not supported in embedded mode (no Dolt server)
```

The extension previously always created the Dolt SQL backend for active projects. That path can try to start a Dolt server while loading Dashboard or Issues, which breaks embedded-mode workspaces.

## Changes

- Add backend selection based on `bd dolt show --json`.
- Use the existing CLI backend for embedded Dolt projects.
- Keep the Dolt SQL backend for server-mode projects.
- Fall back to the previous Dolt SQL backend behavior if mode detection fails.
- Change CLI list loading to use `bd list --all --limit 0 --json`, so the Issues `All` filter can show closed issues too.
- Add regression tests for embedded, server-mode, detection-failure, and CLI list argument behavior.
- Document the fix in `CHANGELOG.md`.

## Testing

- `bun run test`
- `bun run compile:quiet`
- `bun run lint`

Manual checks:

- Opened an embedded Dolt Beads workspace in Extension Development Host.
- Dashboard and Issues no longer show the `bd dolt start` embedded-mode error.
- Switching Issues from `Not Closed` to `All` shows closed issues that were hidden by the CLI default filter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Embedded Dolt projects now load Dashboard and Issues through the CLI backend without requiring `bd dolt start`
  * The `All` filter now includes closed issues

* **Documentation**
  * Updated changelog with latest improvements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jdillon/vscode-beads/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->