### PR TITLE
fix: support new dependencies schema in Details panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `beads.userId` and `beads.pathToBd` now expand `${env:VAR}` placeholders (#60)
-- Embedded Dolt projects now load Dashboard and Issues through the CLI backend without calling `bd dolt start`, including closed issues for the `All` filter.
+- Embedded Dolt projects now load Dashboard and Issues through the CLI backend without calling `bd dolt start`, including closed issues for the `All` filter (#77)
+- Bead Details panel loads on bd >= 1.1 databases where the `dependencies` schema dropped `depends_on_id`; both old and new schemas supported (#79)
 
 ## [0.13.0] - 2026-03-20
 

--- a/src/backend/BeadsDoltBackend.ts
+++ b/src/backend/BeadsDoltBackend.ts
@@ -44,7 +44,7 @@ export class BeadsDoltBackend implements BeadsBackend {
   private pool: mysql.Pool | null = null;
   private connectionInfo: DoltConnectionInfo | null = null;
   private readonly inFlightReads = new Map<string, Promise<unknown>>();
-  private depTargetColumnPromise: Promise<string> | null = null;
+  private depSqlPartsPromise: Promise<{ targetExpr: string; issueTargetColumn: string }> | null = null;
   private poolPromise: Promise<mysql.Pool> | null = null;
 
   constructor(params: {
@@ -284,33 +284,47 @@ export class BeadsDoltBackend implements BeadsBackend {
 
   /**
    * bd >= 1.1 (schema migration 0043) dropped `dependencies.depends_on_id`,
-   * splitting it into typed target columns; older databases still use the
-   * original column. Detect which one exists once per connection (#79).
+   * splitting it into typed target columns (`depends_on_issue_id`,
+   * `depends_on_wisp_id`, `depends_on_external`); older databases still use
+   * the original column. Detect which schema is present once per connection
+   * and derive the SQL fragments for each shape (#79).
    */
-  private async getDepTargetColumn(): Promise<string> {
-    this.depTargetColumnPromise ??= this.query<SqlRow>(`
+  private async getDepSqlParts(): Promise<{ targetExpr: string; issueTargetColumn: string }> {
+    this.depSqlPartsPromise ??= this.query<SqlRow>(`
       SELECT column_name FROM information_schema.columns
       WHERE table_schema = DATABASE()
         AND table_name = 'dependencies'
         AND column_name = 'depends_on_issue_id'
-    `).then((rows) => (rows.length > 0 ? "depends_on_issue_id" : "depends_on_id"));
-    return this.depTargetColumnPromise;
+    `).then((rows) =>
+      rows.length > 0
+        ? {
+            // Typed targets: prefer the issue id, fall back to wisp/external
+            // so those rows still surface with a usable identifier.
+            targetExpr: "COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external)",
+            issueTargetColumn: "depends_on_issue_id",
+          }
+        : {
+            targetExpr: "d.depends_on_id",
+            issueTargetColumn: "depends_on_id",
+          }
+    );
+    return this.depSqlPartsPromise;
   }
 
   private async loadDependencies(issueId: string): Promise<BeadsIssue["dependencies"]> {
-    const targetColumn = await this.getDepTargetColumn();
+    const { targetExpr, issueTargetColumn } = await this.getDepSqlParts();
     const rows = await this.query<SqlRow>(`
       SELECT
-        d.${targetColumn} AS id,
+        ${targetExpr} AS id,
         d.type AS dependency_type,
         i.issue_type,
         i.title,
         i.status,
         i.priority
       FROM dependencies d
-      LEFT JOIN issues i ON i.id = d.${targetColumn}
+      LEFT JOIN issues i ON i.id = d.${issueTargetColumn}
       WHERE d.issue_id = ?
-      ORDER BY d.${targetColumn} ASC
+      ORDER BY id ASC
     `, [issueId]);
 
     return rows.map((row) => ({
@@ -324,7 +338,7 @@ export class BeadsDoltBackend implements BeadsBackend {
   }
 
   private async loadDependents(issueId: string): Promise<BeadsIssue["dependents"]> {
-    const targetColumn = await this.getDepTargetColumn();
+    const { issueTargetColumn } = await this.getDepSqlParts();
     const rows = await this.query<SqlRow>(`
       SELECT
         d.issue_id AS id,
@@ -335,7 +349,7 @@ export class BeadsDoltBackend implements BeadsBackend {
         i.priority
       FROM dependencies d
       LEFT JOIN issues i ON i.id = d.issue_id
-      WHERE d.${targetColumn} = ?
+      WHERE d.${issueTargetColumn} = ?
       ORDER BY d.issue_id ASC
     `, [issueId]);
 
@@ -533,7 +547,7 @@ export class BeadsDoltBackend implements BeadsBackend {
 
   private async resetPool(): Promise<void> {
     this.poolPromise = null;
-    this.depTargetColumnPromise = null;
+    this.depSqlPartsPromise = null;
     if (this.pool) {
       await this.pool.end();
     }

--- a/src/backend/BeadsDoltBackend.ts
+++ b/src/backend/BeadsDoltBackend.ts
@@ -44,6 +44,7 @@ export class BeadsDoltBackend implements BeadsBackend {
   private pool: mysql.Pool | null = null;
   private connectionInfo: DoltConnectionInfo | null = null;
   private readonly inFlightReads = new Map<string, Promise<unknown>>();
+  private depTargetColumnPromise: Promise<string> | null = null;
   private poolPromise: Promise<mysql.Pool> | null = null;
 
   constructor(params: {
@@ -281,19 +282,35 @@ export class BeadsDoltBackend implements BeadsBackend {
     return result;
   }
 
+  /**
+   * bd >= 1.1 (schema migration 0043) dropped `dependencies.depends_on_id`,
+   * splitting it into typed target columns; older databases still use the
+   * original column. Detect which one exists once per connection (#79).
+   */
+  private async getDepTargetColumn(): Promise<string> {
+    this.depTargetColumnPromise ??= this.query<SqlRow>(`
+      SELECT column_name FROM information_schema.columns
+      WHERE table_schema = DATABASE()
+        AND table_name = 'dependencies'
+        AND column_name = 'depends_on_issue_id'
+    `).then((rows) => (rows.length > 0 ? "depends_on_issue_id" : "depends_on_id"));
+    return this.depTargetColumnPromise;
+  }
+
   private async loadDependencies(issueId: string): Promise<BeadsIssue["dependencies"]> {
+    const targetColumn = await this.getDepTargetColumn();
     const rows = await this.query<SqlRow>(`
       SELECT
-        d.depends_on_id AS id,
+        d.${targetColumn} AS id,
         d.type AS dependency_type,
         i.issue_type,
         i.title,
         i.status,
         i.priority
       FROM dependencies d
-      LEFT JOIN issues i ON i.id = d.depends_on_id
+      LEFT JOIN issues i ON i.id = d.${targetColumn}
       WHERE d.issue_id = ?
-      ORDER BY d.depends_on_id ASC
+      ORDER BY d.${targetColumn} ASC
     `, [issueId]);
 
     return rows.map((row) => ({
@@ -307,6 +324,7 @@ export class BeadsDoltBackend implements BeadsBackend {
   }
 
   private async loadDependents(issueId: string): Promise<BeadsIssue["dependents"]> {
+    const targetColumn = await this.getDepTargetColumn();
     const rows = await this.query<SqlRow>(`
       SELECT
         d.issue_id AS id,
@@ -317,7 +335,7 @@ export class BeadsDoltBackend implements BeadsBackend {
         i.priority
       FROM dependencies d
       LEFT JOIN issues i ON i.id = d.issue_id
-      WHERE d.depends_on_id = ?
+      WHERE d.${targetColumn} = ?
       ORDER BY d.issue_id ASC
     `, [issueId]);
 
@@ -515,6 +533,7 @@ export class BeadsDoltBackend implements BeadsBackend {
 
   private async resetPool(): Promise<void> {
     this.poolPromise = null;
+    this.depTargetColumnPromise = null;
     if (this.pool) {
       await this.pool.end();
     }


### PR DESCRIPTION
Fixes #79.

## Problem

bd >= 1.1 (schema migration 0043) dropped `dependencies.depends_on_id`, splitting it into typed target columns (`depends_on_issue_id`, `depends_on_wisp_id`, `depends_on_external`). The Details panel queries still referenced the old column and failed:

```text
[Details] Failed to load bead details: Error: table "d" does not have column "depends_on_id"
```

## Fix

- `getDepTargetColumn()` probes `information_schema.columns` once per connection and selects `depends_on_issue_id` (new schema) or `depends_on_id` (old schema); cached promise cleared on pool reset.
- `loadDependencies`/`loadDependents` use the detected column, so databases on either side of the migration work.

## Testing

- `bun run compile`, `bun run lint`, `tsc --noEmit`, `bun run test` all pass.
- Reproduced the exact error against a fixture project initialized with bd 1.1.0 (post-0043 schema, blocks dependency), then verified the Details panel loads with the dependency rendered after the fix.
- Regression-checked an old-schema project (still has `depends_on_id`) — Details and BLOCKED BY render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Bead Details panel failing to load with newer bd databases using the updated dependency schema.
  * Added compatibility for both older and newer dependency database formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->