### PR TITLE
fix: report missing Beads project instead of spinning forever (#76)

### DIFF
--- a/.agent/skills/vscode-server/scripts/start-dev-environment.sh
+++ b/.agent/skills/vscode-server/scripts/start-dev-environment.sh
@@ -56,6 +56,13 @@ extensions_dir="$HOME/.local/share/code-server/extensions"
 symlink_path="$extensions_dir/$extension_id"
 
 mkdir -p "$extensions_dir"
+
+# A real directory here (e.g. an installed VSIX) would swallow the new link
+if [[ -e "$symlink_path" && ! -L "$symlink_path" ]]; then
+  echo "ERROR:$symlink_path exists and is not a symlink; remove it first"
+  exit 1
+fi
+
 current_link=$(readlink "$symlink_path" 2>/dev/null || echo "")
 
 if [[ "$current_link" == "$project_dir" ]]; then

--- a/.agent/skills/vscode-server/scripts/start-dev-environment.sh
+++ b/.agent/skills/vscode-server/scripts/start-dev-environment.sh
@@ -61,7 +61,9 @@ current_link=$(readlink "$symlink_path" 2>/dev/null || echo "")
 if [[ "$current_link" == "$project_dir" ]]; then
   echo "SYMLINK:verified"
 else
-  ln -sf "$project_dir" "$symlink_path"
+  # -n: don't follow an existing symlink, otherwise the new link lands *inside*
+  # the old target directory and the stale extension keeps loading
+  ln -sfn "$project_dir" "$symlink_path"
   echo "SYMLINK:created"
 fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `beads.projects` setting is now declared so it appears in the Settings UI (#76)
+
 ### Fixed
 
 - `beads.userId` and `beads.pathToBd` now expand `${env:VAR}` placeholders (#60)
 - Embedded Dolt projects now load Dashboard and Issues through the CLI backend without calling `bd dolt start`, including closed issues for the `All` filter (#77)
 - Bead Details panel loads on bd >= 1.1 databases where the `dependencies` schema dropped `depends_on_id`; both old and new schemas supported (#79)
 - Backend-mode detection now times out after 5s so a hung `bd` cannot block project activation
+- Dashboard and Issues views no longer spin on "Loading" forever when no Beads project is found; they show recovery hints, and discovery/`bd` path failures are logged at warn level (#76)
+- Windows absolute paths are no longer treated as project-relative when opening files from bead details (#76)
 
 ## [0.13.0] - 2026-03-20
 

--- a/docs/code-server-testing.md
+++ b/docs/code-server-testing.md
@@ -53,6 +53,18 @@ Reusable fixture projects in `beads-test.code-workspace`:
   (exercises CLI backend routing and the `All` filter)
 - `example-project` — pre-1.1 schema (`depends_on_id`), per-project Dolt server
 
+Throwaway fixture for the "no project found" path (#76) — folder with no `.beads` and a
+`beads.pathToBd` that does not resolve:
+
+```bash
+mkdir -p /tmp/beads-fixture-noproject/.vscode
+echo '{"beads.pathToBd": "tools/bd"}' > /tmp/beads-fixture-noproject/.vscode/settings.json
+# open via http://127.0.0.1:<port>/?folder=/tmp/beads-fixture-noproject
+```
+
+Expected: Dashboard and Issues show "No Beads project found" (no spinner), and Beads.log
+warns about the unresolved `beads.pathToBd` and the failed `bd where` probe.
+
 ### Agent Protocol
 
 When testing with code-server, agents should:
@@ -134,6 +146,11 @@ Use manual builds when watch mode isn't running or after major changes (new file
 - Symlinked extensions use `-dev` suffix convention
 
 ## Troubleshooting
+
+### Testing the wrong checkout (worktrees)
+`readlink ~/.local/share/code-server/extensions/planet57.vscode-beads-dev` must point at the
+checkout you are editing. `ln -sf` on an existing symlink-to-directory writes the new link
+*inside* the old target instead of replacing it — use `ln -sfn` (the start script now does).
 
 ### Extension not loading
 - Check symlink exists: `ls -la ~/.local/share/code-server/extensions/`

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,9 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
   testMatch: ["<rootDir>/src/**/__tests__/**/*.test.ts"],
+  moduleNameMapper: {
+    "^vscode$": "<rootDir>/src/__mocks__/vscode.ts",
+  },
   transform: {
     "^.+\\.ts$": ["ts-jest", { diagnostics: false }],
   },

--- a/package.json
+++ b/package.json
@@ -120,6 +120,14 @@
           "default": "bd",
           "description": "Path to the bd CLI executable. Supports ${env:VAR} placeholders."
         },
+        "beads.projects": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Additional Beads projects to load. Absolute paths to project roots or .beads directories."
+        },
         "beads.refreshInterval": {
           "type": "number",
           "default": 3000,

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -1,0 +1,59 @@
+/**
+ * Minimal `vscode` module stub for jest.
+ *
+ * The real module is only injected by the VS Code host, so tests that import
+ * extension code need this shim. Add members here as tests require them.
+ */
+
+export class EventEmitter<T> {
+  private listeners: Array<(value: T) => void> = [];
+  public readonly event = (listener: (value: T) => void) => {
+    this.listeners.push(listener);
+    return { dispose: () => undefined };
+  };
+  fire(value: T): void {
+    for (const listener of this.listeners) listener(value);
+  }
+  dispose(): void {
+    this.listeners = [];
+  }
+}
+
+export const Uri = {
+  file: (fsPath: string) => ({ fsPath }),
+  joinPath: (base: { fsPath: string }, ...parts: string[]) => ({
+    fsPath: [base.fsPath, ...parts].join("/"),
+  }),
+};
+
+export const window = {
+  showErrorMessage: () => undefined,
+  showWarningMessage: () => undefined,
+  showInformationMessage: () => undefined,
+  setStatusBarMessage: () => undefined,
+  createOutputChannel: () => ({
+    trace: () => undefined,
+    debug: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    appendLine: () => undefined,
+    show: () => undefined,
+    dispose: () => undefined,
+  }),
+};
+
+export const workspace = {
+  workspaceFolders: undefined as Array<{ uri: { fsPath: string } }> | undefined,
+  getConfiguration: () => ({
+    get: <T>(_key: string, defaultValue?: T) => defaultValue,
+  }),
+};
+
+export const commands = {
+  executeCommand: () => undefined,
+};
+
+export const env = {
+  clipboard: { writeText: async () => undefined },
+};

--- a/src/backend/BeadsProjectManager.ts
+++ b/src/backend/BeadsProjectManager.ts
@@ -298,7 +298,7 @@ export class BeadsProjectManager implements vscode.Disposable {
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      this.log.trace(`Discovery probe failed for ${rootPath}: ${message}`);
+      this.log.warn(`Discovery probe failed: ${commandLabel} (cwd=${rootPath}): ${message}`);
       return null;
     }
   }
@@ -435,7 +435,12 @@ export class BeadsProjectManager implements vscode.Disposable {
       return raw;
     }
 
-    return fs.existsSync(raw) ? raw : "bd";
+    if (fs.existsSync(raw)) {
+      return raw;
+    }
+
+    this.log.warn(`Configured beads.pathToBd "${raw}" does not exist; falling back to "bd" on PATH.`);
+    return "bd";
   }
 
   private getBdPath(): string {

--- a/src/backend/BeadsProjectManager.ts
+++ b/src/backend/BeadsProjectManager.ts
@@ -427,15 +427,11 @@ export class BeadsProjectManager implements vscode.Disposable {
 
     const resolvedPath = workspaceRoot && !path.isAbsolute(raw) ? path.resolve(workspaceRoot, raw) : raw;
 
-    if (resolvedPath !== raw && fs.existsSync(resolvedPath)) {
+    if (fs.existsSync(resolvedPath)) {
       return resolvedPath;
     }
 
-    if (path.isAbsolute(raw) || raw === "bd") {
-      return raw;
-    }
-
-    if (fs.existsSync(raw)) {
+    if (raw === "bd") {
       return raw;
     }
 

--- a/src/providers/BaseViewProvider.ts
+++ b/src/providers/BaseViewProvider.ts
@@ -8,6 +8,7 @@
  * - Project context
  */
 
+import * as path from "path";
 import * as vscode from "vscode";
 import { BeadsProjectManager } from "../backend/BeadsProjectManager";
 import {
@@ -211,7 +212,7 @@ export abstract class BaseViewProvider implements vscode.WebviewViewProvider {
     }
 
     // Resolve path relative to project root
-    const resolvedPath = filePath.startsWith("/")
+    const resolvedPath = path.isAbsolute(filePath)
       ? filePath
       : vscode.Uri.joinPath(vscode.Uri.file(project.rootPath), filePath).fsPath;
 

--- a/src/providers/BeadsPanelViewProvider.ts
+++ b/src/providers/BeadsPanelViewProvider.ts
@@ -41,7 +41,10 @@ export class BeadsPanelViewProvider extends BaseViewProvider {
     const thisRequest = ++this.loadSequence;
     const client = this.projectManager.getClient();
     if (!client) {
+      // No project/backend: clear loading so the webview shows the empty state
+      // instead of spinning forever (#76)
       this.postMessage({ type: "setBeads", beads: [] });
+      this.setLoading(false);
       return;
     }
 

--- a/src/providers/DashboardViewProvider.ts
+++ b/src/providers/DashboardViewProvider.ts
@@ -42,7 +42,10 @@ export class DashboardViewProvider extends BaseViewProvider {
           inProgressCount: 0,
         },
       });
+      // No project/backend: clear loading so the webview shows the empty state
+      // instead of spinning forever (#76)
       this.postMessage({ type: "setBeads", beads: [] });
+      this.setLoading(false);
       return;
     }
 

--- a/src/providers/__tests__/no-project-loading-state.test.ts
+++ b/src/providers/__tests__/no-project-loading-state.test.ts
@@ -1,0 +1,53 @@
+import * as vscode from "vscode";
+import { BeadsPanelViewProvider } from "../BeadsPanelViewProvider";
+import { DashboardViewProvider } from "../DashboardViewProvider";
+import { BeadsProjectManager } from "../../backend/BeadsProjectManager";
+import { BaseViewProvider } from "../BaseViewProvider";
+import { ExtensionToWebviewMessage } from "../../backend/types";
+import { Logger } from "../../utils/logger";
+
+type ProviderCtor = new (
+  extensionUri: vscode.Uri,
+  projectManager: BeadsProjectManager,
+  logger: Logger
+) => BaseViewProvider;
+
+function createProvider(Provider: ProviderCtor) {
+  const posted: ExtensionToWebviewMessage[] = [];
+
+  // No active project => no backend client
+  const projectManager = {
+    getClient: () => null,
+    getActiveProject: () => null,
+    getProjects: () => [],
+  } as unknown as BeadsProjectManager;
+
+  const logger = new Logger(vscode.window.createOutputChannel() as unknown as vscode.LogOutputChannel);
+  const provider = new Provider({} as vscode.Uri, projectManager, logger);
+
+  // Stand in for the resolved webview view
+  (provider as unknown as { _view: unknown })._view = {
+    visible: true,
+    webview: { postMessage: (message: ExtensionToWebviewMessage) => posted.push(message) },
+  };
+
+  const loadData = (provider as unknown as {
+    loadData: (reason: "initial") => Promise<void>;
+  }).loadData.bind(provider);
+
+  return { loadData, posted };
+}
+
+describe.each([
+  ["BeadsPanelViewProvider", BeadsPanelViewProvider as unknown as ProviderCtor],
+  ["DashboardViewProvider", DashboardViewProvider as unknown as ProviderCtor],
+])("%s without a backend client", (_name, Provider) => {
+  it("clears the loading state so the webview can show the empty state", async () => {
+    const { loadData, posted } = createProvider(Provider);
+
+    await loadData("initial");
+
+    expect(posted).toContainEqual({ type: "setLoading", loading: false });
+    expect(posted).not.toContainEqual({ type: "setLoading", loading: true });
+  });
+});

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -18,6 +18,7 @@ import { DashboardView } from "./views/DashboardView";
 import { IssuesView } from "./views/IssuesView";
 import { DetailsView } from "./views/DetailsView";
 import { Loading } from "./common/Loading";
+import { NoProject } from "./common/NoProject";
 import { ToastProvider, triggerToast } from "./common/Toast";
 
 interface AppState {
@@ -107,6 +108,15 @@ export function App(): React.ReactElement {
 
   // Render the appropriate view
   const renderView = () => {
+      // Discovery finished without a project: show how to fix it, not a spinner (#76)
+      if (
+        !state.loading &&
+        !state.project &&
+        (state.viewType === "beadsPanel" || state.viewType === "beadsDashboard")
+      ) {
+        return <NoProject />;
+      }
+
       if (state.viewType === "beadsPanel" && state.loading && state.beads.length === 0) {
         return <Loading />;
       }

--- a/src/webview/common/NoProject.tsx
+++ b/src/webview/common/NoProject.tsx
@@ -1,0 +1,23 @@
+/**
+ * NoProject Component
+ *
+ * Shown when no Beads project could be discovered, with recovery hints.
+ */
+
+import React from "react";
+
+export function NoProject(): React.ReactElement {
+  return (
+    <div className="empty-state">
+      <h3>No Beads project found</h3>
+      <p>
+        Run <code>bd init</code> in your project, or add the project root to the{" "}
+        <code>beads.projects</code> setting.
+      </p>
+      <p>
+        If <code>bd</code> is not on your PATH, set <code>beads.pathToBd</code> to its
+        full path. See Output &gt; Beads for details.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes #76

## Problem

`BeadsPanelViewProvider.loadData()` and `DashboardViewProvider.loadData()` early-returned when `projectManager.getClient()` returned null, without calling `setLoading(false)`. The webview's initial state is `loading: true`, so whenever project discovery failed the UI spun on "Loading" forever and never explained why. `BeadDetailsViewProvider` already handled this correctly.

Platform-independent — reproduces anywhere by opening a folder where discovery fails. The reporter hit it on Windows 11 / Kiro (stale PATH in a GUI-launched editor, so `bd` was not found); that environment issue is theirs to fix, but the extension should say so instead of hanging.

## Changes

- Both providers clear the loading state on the null-client path.
- New `src/webview/common/NoProject.tsx` empty state ("No Beads project found" + `bd init` / `beads.projects` / `beads.pathToBd` hints), rendered by `App` for the panel and dashboard views when discovery finished with no project. Reuses existing `.empty-state` styles — no new CSS.
- `bd where` discovery probe failures now log at **warn** (was trace) and include the bd path and cwd, so the reason is visible in Output > Beads at the default log level.
- `resolveBdPath()` warns and falls back to `bd` on PATH whenever the configured `beads.pathToBd` does not exist — absolute or relative.
- Declared `beads.projects` in `contributes.configuration` — it was read by `getConfiguredProjectPaths()` but never declared, so it never appeared in the Settings UI.
- `BaseViewProvider.handleOpenFile()` uses `path.isAbsolute()` instead of `filePath.startsWith("/")`, which misdetected Windows absolute paths (`C:\...`) as relative.

## Tests

`src/providers/__tests__/no-project-loading-state.test.ts` covers both providers on the null-client path. Needed a `vscode` module stub (`src/__mocks__/vscode.ts` + jest `moduleNameMapper`) since the real module only exists inside the VS Code host. Verified the test fails without the provider fix.

`bun run compile`, `bun run lint`, `bun run test`, `tsc --noEmit` all pass.

## Manual verification (code-server)

Fixture: a folder with no `.beads` dir and a `beads.pathToBd` that does not resolve — recipe added to `docs/code-server-testing.md`.

- Before (main): Dashboard and Issues both spin on "Loading" indefinitely.
- After: both render "No Beads project found" with the recovery hints, no spinner.
- Beads.log at default level:
  ```
  [warning] [ProjectManager] Configured beads.pathToBd "tools/bd" does not exist; falling back to "bd" on PATH.
  [warning] [ProjectManager] Discovery probe failed: bd where (cwd=/tmp/beads-fixture-noproject): Command failed: bd where
  Error: No active beads workspace found.
  ```
- No regression: reopening a real Beads project loads the dashboard counts and issue table as before.

Verification was done before the CodeRabbit fix to `resolveBdPath`, so the run above exercised the relative-path fallback; missing *absolute* paths now take the same warn-and-fall-back route.

Second commit is unrelated tooling fallout found during that verification: the dev-env start script used `ln -sf` on an existing symlink-to-directory, which writes the new link *inside* the old target — code-server kept loading a stale checkout. Now `ln -sfn`, plus a guard against a non-symlink destination, with the trap documented.

## Not done

Left the discovery probe parsing the first line of plain-text `bd where` output rather than switching to `bd where --json`. `--json` works on bd 1.1.2, but the extension supports back to bd 0.51.0 and I could not verify `--json` there; an unknown flag would make `execFile` reject and break discovery entirely for older bd. Worth doing separately with a version check or a plain-text retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Settings option to configure additional Beads projects.
  * Added a “No Project” recovery screen with guidance when no Beads project is found.
* **Bug Fixes**
  * Fixed stuck loading spinners in empty-state webviews.
  * Improved handling of Windows absolute paths and clearer probe/log warnings.
  * Hardened backend discovery (including safer `beads.pathToBd` fallback) and improved backend-mode detection reliability.
  * Improved symlink replacement for the development setup to prevent incorrect targets.
* **Documentation**
  * Expanded testing and troubleshooting guidance for missing projects and extension symlinks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->