### PR TITLE
docs: correct README for release and expand the release test fixture

### DIFF
--- a/.agent/skills/vscode-server/scripts/make-test-fixture.sh
+++ b/.agent/skills/vscode-server/scripts/make-test-fixture.sh
@@ -8,19 +8,41 @@
 # test data - build a fixture instead.
 #
 # Usage:
-#   make-test-fixture.sh [target-dir]        # default: /tmp/bd-test-fixture
+#   make-test-fixture.sh [--server] [target-dir]   # default: /tmp/bd-test-fixture
+#
+#   --server   Use an external dolt sql-server (bd manages it) instead of the
+#              embedded engine. Embedded exercises the CLI backend; --server
+#              exercises the Dolt SQL backend. Both paths need testing before a
+#              release. Tear a server fixture down with `bd dolt stop` from the
+#              fixture directory.
 #
 # Output (parse these):
 #   FIXTURE_DIR:<path>
+#   FIXTURE_MODE:<embedded|server>
 #   FIXTURE_BEADS:<count>
 #   ERROR:<message>
 #
-# The fixture uses embedded Dolt (bd init default), which exercises the CLI
-# backend. For the Dolt SQL backend, re-init with --server.
+# What it covers - see docs/code-server-testing.md for the verification pass:
+#   every issue type the extension styles, every bd built-in status plus a
+#   custom one, all four dependency types, priorities P0-P4, a fully populated
+#   bead (markdown description, design, acceptance, notes, labels, assignee,
+#   estimate, external ref, due date), multi-author comments, and beads of the
+#   types bd hides by default.
 
 set -euo pipefail
 
-target_dir="${1:-/tmp/bd-test-fixture}"
+mode="embedded"
+target_dir=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --server) mode="server"; shift ;;
+    -h|--help) sed -n '3,29p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -*) echo "ERROR:unknown option '$1'"; exit 1 ;;
+    *) target_dir="$1"; shift ;;
+  esac
+done
+target_dir="${target_dir:-/tmp/bd-test-fixture}"
 prefix="fixture"
 
 for tool in bd jq; do
@@ -49,13 +71,21 @@ if [ -e "$target_dir" ] && [ ! -d "$target_dir/.beads" ]; then
   exit 1
 fi
 
+# A server-mode fixture leaves a dolt sql-server running against the old data
+# directory; stop it before the directory goes away.
+if [ -d "$target_dir/.beads" ]; then
+  (cd "$target_dir" && bd dolt stop >/dev/null 2>&1) || true
+fi
+
 rm -rf -- "$target_dir"
 mkdir -p "$target_dir"
 cd "$target_dir"
 git init -q .
 
-if ! bd init --prefix "$prefix" --non-interactive >/dev/null 2>&1; then
-  echo "ERROR:bd init failed in $target_dir"
+init_args=(--prefix "$prefix" --non-interactive)
+[ "$mode" = "server" ] && init_args+=(--server)
+if ! bd init "${init_args[@]}" >/dev/null 2>&1; then
+  echo "ERROR:bd init failed in $target_dir (mode=$mode)"
   exit 1
 fi
 
@@ -63,23 +93,77 @@ new() { # new <type> <priority> <title>
   bd create --title "$3" --type "$1" --priority "$2" --silent
 }
 
-# --- issue types: every bd built-in the extension styles -------------------
+# --- issue types: every built-in the extension gives a label, color and icon --
 t_task=$(new task 1 "Task - blocker")
 t_task2=$(new task 2 "Task - blocked by the blocker")
-new bug 0 "Bug bead" >/dev/null
-new feature 2 "Feature bead" >/dev/null
-new epic 0 "Epic bead" >/dev/null
-new chore 3 "Chore bead" >/dev/null
+t_bug=$(new bug 0 "Bug bead - P0, critical")
+new chore 3 "Chore bead - P3" >/dev/null
 new decision 2 "Decision bead" >/dev/null
 new spike 3 "Spike bead" >/dev/null
 new story 2 "Story bead" >/dev/null
 new milestone 1 "Milestone bead" >/dev/null
+new event 4 "Event bead - P4, backlog" >/dev/null
+new molecule 2 "Molecule bead" >/dev/null
 
-# --- dependency: gives the Details panel a non-empty BLOCKS list -----------
-# (bd only allows task->task blocking, hence two tasks above)
+# Types bd hides from a default `bd list`. Both backends should agree and keep
+# these out of the issue list; if one shows up in the UI, that is the bug.
+new gate 2 "Gate bead - should NOT appear in the issue list" >/dev/null
+new message 2 "Message bead - should NOT appear in the issue list" >/dev/null
+
+# --- a fully populated bead: every Details panel section is non-empty ---------
+rich=$(bd create --title "Rich bead - every field populated" \
+  --type feature --priority 0 \
+  --assignee jdillon \
+  --labels ui,release-test,markdown \
+  --estimate 90 \
+  --external-ref gh-76 \
+  --due +2w \
+  --description "$(cat <<'MD'
+## Overview
+
+This bead exists to exercise **markdown rendering** in the Details panel.
+
+- bullet one
+- bullet two with `inline code`
+- [a link](https://github.com/jdillon/vscode-beads)
+
+```ts
+const check = (s: string) => s.trim().length > 0;
+```
+
+> Blockquote, to confirm it is styled.
+MD
+)" \
+  --design "$(cat <<'MD'
+Renders through the same markdown path as the description.
+
+1. numbered
+2. list
+MD
+)" \
+  --acceptance "$(cat <<'MD'
+- [ ] Description renders as markdown
+- [ ] Design, acceptance and notes sections all appear
+- [ ] Labels, assignee, estimate and external ref show in the header
+MD
+)" \
+  --notes "Notes field. Should render below acceptance criteria." \
+  --silent)
+
+# --- hierarchy: an epic with children (exercises parent-child) ----------------
+epic=$(new epic 0 "Epic bead - has two children")
+bd create --title "Child of the epic - first" --type task --priority 2 --parent "$epic" --silent >/dev/null
+bd create --title "Child of the epic - second" --type task --priority 3 --parent "$epic" --silent >/dev/null
+
+# --- dependencies: all four types the extension renders -----------------------
+# (bd only allows task->task blocking, hence the two tasks above)
 bd dep add "$t_task2" "$t_task" --type blocks >/dev/null
+d_related=$(new task 2 "Related to the rich bead")
+bd dep add "$d_related" "$rich" --type related >/dev/null
+d_found=$(new bug 1 "Discovered while working the blocker")
+bd dep add "$d_found" "$t_task" --type discovered-from >/dev/null
 
-# --- statuses: every bd built-in, plus a user-defined one ------------------
+# --- statuses: every bd built-in, plus a user-defined one ---------------------
 s_deferred=$(new task 1 "Status: deferred")
 bd defer "$s_deferred" --reason "fixture" >/dev/null
 
@@ -93,18 +177,21 @@ s_blocked=$(new task 2 "Status: blocked")
 bd update "$s_blocked" --status blocked >/dev/null
 
 s_wip=$(new task 2 "Status: in progress")
-bd update "$s_wip" --status in_progress >/dev/null
+bd update "$s_wip" --status in_progress --assignee agent-two >/dev/null
 
 s_closed=$(new task 3 "Status: closed")
 bd close "$s_closed" --reason "fixture" >/dev/null
 
-# Custom status must be registered before it can be assigned.
+# Custom status must be registered before it can be assigned. Nothing upstream
+# constrains the vocabulary, so the UI has to cope with a value it never saw.
 bd config set status.custom "awaiting_review" >/dev/null
 s_custom=$(new task 3 "Status: custom (awaiting_review)")
-bd update "$s_custom" --status awaiting_review >/dev/null
+bd update "$s_custom" --status awaiting_review --assignee agent-three >/dev/null
 
-# --- a comment, so the Details comments section is non-empty ---------------
-bd comments add "$t_task" "Fixture comment" >/dev/null
+# --- comments: multi-author, so the Details comments section has variety -------
+bd comments add "$rich" "First comment, from the fixture author." --author jdillon >/dev/null
+bd comments add "$rich" "Second comment, different author, with \`inline code\`." --author agent-two >/dev/null
+bd comments add "$t_task" "Single comment on the blocker." --author jdillon >/dev/null
 
 # Validate structurally and fail closed: `| grep -c` prints 0 on a failed
 # `bd list` and still reads like a successful result.
@@ -122,4 +209,5 @@ if [ "$count" -lt 1 ]; then
 fi
 
 echo "FIXTURE_DIR:$target_dir"
+echo "FIXTURE_MODE:$mode"
 echo "FIXTURE_BEADS:$count"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `beads.userId` and `beads.pathToBd` now expand `${env:VAR}` placeholders (#60)
 - Embedded Dolt projects now load Dashboard and Issues through the CLI backend without calling `bd dolt start`, including closed issues for the `All` filter (#77)
 - Bead Details panel loads on bd >= 1.1 databases where the `dependencies` schema dropped `depends_on_id`; both old and new schemas supported (#79)
+- Refresh now activates a newly discovered project instead of leaving views empty (#64)
 - Backend-mode detection now times out after 5s so a hung `bd` cannot block project activation
 - Dashboard and Issues views no longer spin on "Loading" forever when no Beads project is found; they show recovery hints, and discovery/`bd` path failures are logged at warn level (#76)
 - Windows absolute paths are no longer treated as project-relative when opening files from bead details (#76)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ VS Code extension for managing [Beads](https://github.com/steveyegge/beads) issu
 - All Beads operations go through CLI (`bd list --json`, `bd show <id> --json`, etc.) - never access `.beads` files directly
 - Status/priority normalization in `src/backend/types.ts` - CLI returns various formats, extension normalizes to internal types
 - Webview↔Extension communication via typed messages (`ExtensionToWebviewMessage`, `WebviewToExtensionMessage`)
-- Single webview bundle at `dist/webview/main.js` serves all 5 views; view type determines which component renders
+- Single webview bundle at `dist/webview/main.js` serves all views (Dashboard, Issues, Details); view type determines which component renders
 - **Prefer components over ad-hoc markup**: Extract reusable UI elements into `src/webview/common/` components (e.g., `StatusBadge`, `FilterChip`) rather than inline spans with class names
 - **No native HTML controls**: Don't use native `<select>`, `<input type="checkbox">`, etc. Use custom components (`Dropdown`, `ColoredSelect`) for consistent VS Code-themed styling
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="resources/icon.png" alt="Beads icon" width="128" align="right">
 
-VS Code extension for managing [Beads](https://github.com/steveyegge/beads) issues. Uses `bd` for project discovery and Dolt lifecycle control, and reads issue data directly from Dolt SQL for a faster UI.
+VS Code extension for managing [Beads](https://github.com/steveyegge/beads) issues. Uses `bd` for project discovery and Dolt lifecycle control. Projects backed by a Dolt SQL server are read directly over SQL for a faster UI; projects using embedded Dolt go through the `bd` CLI.
 
 ![Beads VS Code Extension](docs/images/beads-vscode-screenshot.png)
 
@@ -12,7 +12,7 @@ VS Code extension for managing [Beads](https://github.com/steveyegge/beads) issu
 
 - Toggle between Table and Board views for issues
 - Drag cards between columns to change status
-- See status distribution at a glance (Open, In Progress, Blocked, Closed)
+- See status distribution at a glance, including deferred, pinned, hooked and custom statuses
 - All columns collapsible for focused workflow (closed by default)
 - Cards show title, ID, type, priority, assignee, and labels
 - Filter-aware: shows "3/5" count when filters hide items
@@ -26,7 +26,7 @@ VS Code extension for managing [Beads](https://github.com/steveyegge/beads) issu
 - Filter by status, priority, type, assignee, and labels
 - Multi-column sorting (shift+click for secondary sort)
 - Persistent column visibility, order, and sort preferences
-- Filter presets: Not Closed, Blocked, Epics
+- Filter presets: All, Not Closed, Active, Blocked, Closed
 - Click-to-copy bead IDs
 
 **Details Panel**
@@ -34,7 +34,7 @@ VS Code extension for managing [Beads](https://github.com/steveyegge/beads) issu
 - View/edit title, description, status, priority, type, labels, assignee
 - Colored inline dropdowns for quick field editing
 - Markdown rendering in description/notes with timezone-aware timestamps
-- Dependency management with grouped relationship types (blocks, related, parent-child)
+- Dependency management with grouped relationship types (blocks, parent-child, related, discovered-from)
 
 **Multi-Project & Dolt-Aware UI**
 
@@ -50,7 +50,7 @@ See [docs/development.md](docs/development.md) for build commands, architecture,
 ## Requirements
 
 - VS Code 1.85.0+
-- Beads CLI (`bd`) in PATH
+- Beads CLI (`bd`) 1.0.5+ in PATH
 - Initialized project (`bd init`)
 
 ## Installation
@@ -82,20 +82,25 @@ Install from [VS Code Marketplace](https://marketplace.visualstudio.com/items?it
 
 ## Commands
 
-| Command                   | Description                     |
-| ------------------------- | ------------------------------- |
-| `Beads: Switch Project`   | Select active project           |
-| `Beads: Refresh`          | Refresh all views               |
-| `Beads: Create New Issue` | Create issue via quick input    |
-| `Beads: Start Dolt Server` | Start Dolt for active project  |
-| `Beads: Stop Dolt Server`  | Stop Dolt for active project   |
-| `Beads: Show Dolt Status`  | Log Dolt status for the project |
+Available in the Command Palette:
+
+| Command                     | Description             |
+| --------------------------- | ----------------------- |
+| `Beads: Switch Project`     | Select active project   |
+| `Beads: Refresh`            | Refresh all views       |
+| `Beads: Open Issues Panel`  | Focus the Issues view   |
+| `Beads: Open Issue Details` | Focus the Details view  |
+| `Beads: Copy Issue ID`      | Copy the selected bead ID |
+
+Starting and stopping Dolt, showing Dolt status, and opening the Dolt log are dashboard
+controls rather than palette commands.
 
 ## Settings
 
 | Setting                 | Default | Description                                         |
 | ----------------------- | ------- | --------------------------------------------------- |
 | `beads.pathToBd`          | `"bd"`  | Path to `bd` CLI                                     |
+| `beads.projects`          | `[]`    | Extra project paths to load (project root or `.beads`) |
 | `beads.refreshInterval`   | `3000`  | Dolt change polling interval in ms (0 = disable)     |
 | `beads.renderMarkdown`    | `true`  | Render markdown in text fields                       |
 | `beads.userId`            | `""`    | Your user ID for "Assign to me" (defaults to $USER)  |

--- a/docs/code-server-testing.md
+++ b/docs/code-server-testing.md
@@ -53,21 +53,55 @@ feature is broken" when it is really the fixture that is missing.
 ### Generated fixture (preferred)
 
 ```bash
-.agent/skills/vscode-server/scripts/make-test-fixture.sh [target-dir]
+.agent/skills/vscode-server/scripts/make-test-fixture.sh [--server] [target-dir]
 # default target: /tmp/bd-test-fixture
-# prints FIXTURE_DIR:<path> and FIXTURE_BEADS:<count>
+# prints FIXTURE_DIR:<path>, FIXTURE_MODE:<embedded|server>, FIXTURE_BEADS:<count>
 ```
 
-Destroys and recreates the target, so it is safe to re-run. Covers every bd
-built-in status (`open`, `in_progress`, `blocked`, `deferred`, `pinned`,
-`hooked`, `closed`), a user-defined status via `status.custom`, nine issue
-types, a `blocks` dependency (non-empty Details BLOCKS list) and a comment.
+Destroys and recreates the target, so it is safe to re-run. 23 beads covering:
 
-Uses embedded Dolt, which routes through the **CLI backend**. Re-init with
-`--server` to exercise the **Dolt SQL backend** — the two backends differ, so a
-change touching either must be tested on the matching fixture.
+- every bd built-in status (`open`, `in_progress`, `blocked`, `deferred`,
+  `pinned`, `hooked`, `closed`) plus a user-defined one via `status.custom`
+- every issue type the extension styles, plus `gate` and `message` — the types
+  bd hides from a default `bd list`, which must stay out of the UI too
+- all four dependency types (`blocks`, `parent-child`, `related`,
+  `discovered-from`) and an epic with two children
+- priorities P0–P4, three assignees plus unassigned beads
+- a fully populated bead: markdown description (headings, list, code fence,
+  link, blockquote), design, acceptance criteria, notes, three labels,
+  estimate, external ref, due date, two comments from different authors
 
-Open it with `?folder=<FIXTURE_DIR>` and accept the workspace-trust prompt.
+Without `--server` the fixture uses embedded Dolt, routing through the **CLI
+backend**. With `--server` bd runs a real `dolt sql-server`, routing through the
+**Dolt SQL backend**. The two backends have separate query paths and have
+diverged before (#79, F2/F4 of the bd 1.1.2 audit), so a release check needs
+both:
+
+```bash
+.agent/skills/vscode-server/scripts/make-test-fixture.sh /tmp/bd-release-fixture
+.agent/skills/vscode-server/scripts/make-test-fixture.sh --server /tmp/bd-release-fixture-server
+```
+
+Stop a server fixture with `bd dolt stop` from its directory when done; re-running
+the script against the same path does this for you.
+
+Open either with `?folder=<FIXTURE_DIR>` and accept the workspace-trust prompt.
+
+### Release verification pass
+
+Against both fixtures, checking Dashboard, Issues and Details:
+
+| Check | Expected |
+|---|---|
+| Bead count | 23 total; `gate` and `message` beads absent from the issue list |
+| Dashboard BY STATUS | all 8 statuses listed, badge and bar colors agree, fills proportional |
+| Type icons | every type renders its own icon and color, none fall back to a blank |
+| Filters | status chips include deferred/pinned/hooked; custom `awaiting_review` filterable |
+| Details → rich bead | markdown renders; design, acceptance, notes sections present; labels, assignee, estimate, external ref in header |
+| Details → dependencies | BLOCKS, related, discovered-from and parent-child all render; dependents ("blocked by") non-empty |
+| Details → dropdowns | status dropdown on the `awaiting_review` bead shows its own value as selected |
+| Details → comments | rich bead shows 2 comments with distinct authors |
+| Kanban | columns derived from data, including the custom status |
 
 ### Long-lived fixtures in `beads-test.code-workspace`
 


### PR DESCRIPTION
Pre-release documentation audit. README had drifted from the code in several places.

## README fixes

- **`Beads: Create New Issue` does not exist.** Nothing registers or contributes it — it was documented but unreachable. Commands table now lists the five commands actually contributed to the palette (`Switch Project`, `Refresh`, `Open Issues Panel`, `Open Issue Details`, `Copy Issue ID`), with a note that the Dolt start/stop/status actions are dashboard controls, not palette commands.
- **Filter presets were wrong** — documented as "Not Closed, Blocked, Epics", actually All / Not Closed / Active / Blocked / Closed.
- **Dependency types omitted `discovered-from`.**
- **Requirements now state bd 1.0.5+**, the floor introduced with `bd show --include-dependents` (#84).
- **`beads.projects` added to the Settings table** — declared in #83 but never documented.
- **Summary line corrected**: it claimed all reads go through Dolt SQL, which stopped being true once embedded-Dolt projects started routing through the bd CLI (#78).
- Kanban status wording updated for `deferred`/`pinned`/`hooked`/custom.

## CHANGELOG

Adds the #64 refresh fix — the only user-facing change since v0.13.0 that shipped without a changelog entry. Everything else was already logged by the PR that introduced it.

## Test fixture

`make-test-fixture.sh` now takes `--server`, so one script produces both an embedded (CLI backend) and a server (Dolt SQL backend) project — the two paths that have diverged before (#79, and F2/F4 of the bd 1.1.2 audit). 23 beads covering every status including a custom one, every issue type plus the ones bd hides, all four dependency types, an epic with children, P0–P4, and one fully populated bead with markdown, labels, estimate, external ref and multi-author comments.

`docs/code-server-testing.md` gains the matching release verification pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Refresh now activates newly discovered projects, preventing empty views.

- **Documentation**
  - Clarified support for embedded and SQL-server project setups.
  - Documented additional project paths, updated issue filters, dependency types, statuses, and command usage.
  - Updated the required Beads CLI version to 1.0.5 or newer.
  - Expanded testing guidance across dashboards, filters, issue details, comments, and Kanban views.

- **Testing**
  - Added broader test fixtures covering statuses, issue types, dependencies, priorities, assignees, comments, and metadata.
  - Added verification guidance for both supported storage backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->