### PR TITLE
chore: update upstream beads repo references to gastownhall/beads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ code --install-extension vscode-beads-0.1.0.vsix
 
 ## Architecture
 
-VS Code extension for managing [Beads](https://github.com/steveyegge/beads) issues via `bd` CLI.
+VS Code extension for managing [Beads](https://github.com/gastownhall/beads) issues via `bd` CLI.
 
 ### Data Flow
 
@@ -105,7 +105,7 @@ Use [Font Awesome Free](https://fontawesome.com) icons unless there's a good rea
 
 ## Upstream Sync
 
-Periodically check [steveyegge/beads](https://github.com/steveyegge/beads) for changes that affect this extension:
+Periodically check [gastownhall/beads](https://github.com/gastownhall/beads) for changes that affect this extension:
 
 - **Daemon API**: Check `internal/rpc/protocol.go` and `internal/types/types.go` for new operations, fields, or type changes. Update `BeadsDaemonClient.ts` and `docs/reference/beads-daemon-api.md`.
 - **Bead types**: Check for new `issue_type` values (e.g., `merge-request`, `molecule`). Update `BeadType`, `TYPE_LABELS`, `TYPE_COLORS`, `TYPE_SORT_ORDER` in `src/webview/types.ts` and add icons.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="resources/icon.png" alt="Beads icon" width="128" align="right">
 
-VS Code extension for managing [Beads](https://github.com/steveyegge/beads) issues. Uses `bd` for project discovery and Dolt lifecycle control. Projects backed by a Dolt SQL server are read directly over SQL for a faster UI; projects using embedded Dolt go through the `bd` CLI.
+VS Code extension for managing [Beads](https://github.com/gastownhall/beads) issues. Uses `bd` for project discovery and Dolt lifecycle control. Projects backed by a Dolt SQL server are read directly over SQL for a faster UI; projects using embedded Dolt go through the `bd` CLI.
 
 <img src="docs/images/beads-issues.png" alt="Beads VS Code Extension" width="750">
 

--- a/docs/reference/beads-caveats.md
+++ b/docs/reference/beads-caveats.md
@@ -9,7 +9,7 @@ Notes on beads behavior, naming changes, and gotchas encountered during developm
 - Changed in beads v0.25.1 (JSONL Canonicalization, bd-6xd)
 - Old `beads.jsonl` name is legacy
 - Source: `internal/configfile/configfile.go:24`
-- Reference: https://github.com/steveyegge/beads/issues/409#issuecomment-3592298397
+- Reference: https://github.com/gastownhall/beads/issues/409#issuecomment-3592298397
 
 If you have an older setup with `beads.jsonl`, beads should handle migration automatically, but verify your `.beads/.gitignore` references the correct filename.
 
@@ -17,7 +17,7 @@ If you have an older setup with `beads.jsonl`, beads should handle migration aut
 
 `bd doctor` may show warnings immediately after `bd init` - this is a known UX issue. A fresh init shouldn't require doctor fixes.
 
-Reference: https://github.com/steveyegge/beads/issues/409
+Reference: https://github.com/gastownhall/beads/issues/409
 
 ## Protected Branch Worktree
 

--- a/docs/upstream-sync/README.md
+++ b/docs/upstream-sync/README.md
@@ -1,6 +1,6 @@
 # Upstream Beads Sync
 
-Tracks synchronization between vscode-beads and upstream [beads](https://github.com/steveyegge/beads).
+Tracks synchronization between vscode-beads and upstream [beads](https://github.com/gastownhall/beads).
 
 ## Current Sync Point
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -332,7 +332,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       "Learn More"
     ).then((action) => {
       if (action === "Learn More") {
-        vscode.env.openExternal(vscode.Uri.parse("https://github.com/steveyegge/beads"));
+        vscode.env.openExternal(vscode.Uri.parse("https://github.com/gastownhall/beads"));
       }
     });
   }


### PR DESCRIPTION
The upstream beads repository was renamed from `steveyegge/beads` to `gastownhall/beads`. Old URLs still redirect, but this points docs and the "Learn More" link at the canonical location.

Surfaced while diagnosing #76 — the local reference clone's remote was stale, which nearly put the wrong install URL in a reply to a user.

Left alone: `sandbox/` and the dated `docs/upstream-sync/2026-07-27-*.md` snapshot — historical, redirects cover them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Beads repository links throughout the documentation to the Gastown Hall repository.
  - Revised caveats and upstream synchronization references to point to the current repository.

- **User Experience**
  - Updated the “Learn More” link shown when no Beads projects are found to open the current repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->